### PR TITLE
Add CODEOWNERS for arkivlaget

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FINTLabs/arkivlaget


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @FINTLabs/arkivlaget` so arkivlaget is set as code owner for repository files.